### PR TITLE
Instruct Usage Of Tags For Installation And Upgrade

### DIFF
--- a/v1/installation.md
+++ b/v1/installation.md
@@ -16,7 +16,7 @@ To run SendPortal, your environment must meet a few minimum requirements:
 Clone the repository to your environment, using the following command:
 
 ```bash
-git clone https://github.com/mettle/sendportal.git
+git clone --depth 1 --branch v1.0.3 https://github.com/mettle/sendportal.git
 ```
 
 ### Install Dependencies

--- a/v2/installation.md
+++ b/v2/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-As of Version 2, Sendportal can be installed as a stand-alone application (i.e. including everything you need to run SendPortal), or as a package inside an existing Laravel application. 
+As of Version 2, Sendportal can be installed as a stand-alone application (i.e. including everything you need to run SendPortal), or as a package inside an existing Laravel application.
 
 This page covers the stand-alone installation. If you want to install SendPortal as a package, then head over to the [Package Installation guide](/docs/v2/getting-started/package-installation).
 
@@ -21,7 +21,7 @@ To run SendPortal, your environment must meet a few minimum requirements:
 Clone the repository to your environment, using the following command:
 
 ```bash
-git clone https://github.com/mettle/sendportal.git
+git clone --depth 1 --branch v2.0.0 https://github.com/mettle/sendportal.git
 ```
 
 ### Install Dependencies

--- a/v2/upgrade-guide.md
+++ b/v2/upgrade-guide.md
@@ -2,6 +2,8 @@
 
 > Please see the "Notable Changes" section at the bottom of this document for a list of changes that could impact your use of SendPortal after the upgrade.
 
+> If you do not wish to upgrade to v2, please see the "Sticking With v1" section at the bottom of this document.
+
 ## Requirements
 
 > We recommend creating a database backup for your SendPortal installation before proceeding with the v2 upgrade.
@@ -12,11 +14,23 @@ SendPortal v2 bumps the minimum supported version of PHP from 7.2.5 to __7.3__.
 > We recommend using the latest version of PHP possible, as older versions no longer receive bug fixes or security updates.
 
 ## Updating To The Latest Version
-Get the latest version of SendPortal by performing a git pull from GitHub:
+To get the latest version of SendPortal, you must checkout the new v2 tag.
+
+First, ensure you are in your SendPortal installation directory:
 
 ```
 cd /path/to/sendportal
-git pull origin master
+```
+
+Then use git to checkout the `v2.0.0` tag:
+
+```
+git checkout v2.0.0
+```
+
+Finally, update SendPortal's dependencies:
+
+```
 composer update
 ```
 
@@ -33,8 +47,15 @@ php artisan sp:upgrade
 ### Manual Upgrade
 If you prefer to perform the upgrade steps manually, you will need to do the following:
 
-- Apply migrations with `php artisan migrate`
-- Republish assets with `php artisan vendor:publish --provider='Sendportal\Base\SendportalBaseServiceProvider' --force`
+Apply migrations:
+```
+php artisan migrate
+```
+
+Republish assets:
+```
+php artisan vendor:publish --provider='Sendportal\Base\SendportalBaseServiceProvider' --force
+```
 
 ## Laravel Horizon
 If you are using Laravel Horizon to manage redis queues, you will need to republish its assets for it to continue working with the new version of SendPortal:
@@ -49,7 +70,7 @@ php artisan horizon:publish
 The following functionality has changed between v1 and v2. Please check to see if any of these changes impact your use of SendPortal before you upgrade.
 
 ### API Tokens Are Now On Workspaces
-API tokens were previously attached a user, but these have now been moved to a workspace. User API tokens have been removed. To continue using the API you will need to generate an API token for your workspace(s). See [API Introduction](/docs/v2/api/introduction) for more information on how to do this.
+API tokens were previously attached to a user, but these have now been moved to a workspace. User API tokens have been removed. To continue using the API you will need to generate an API token for your workspace(s). See [API Introduction](/docs/v2/api/introduction) for more information on how to do this.
 
 ### Workspace API Removed
 Because API tokens are now per-workspace, the workspace API that allowed a user to fetch a list of workspaces has been removed.
@@ -59,3 +80,26 @@ Segments have been renamed to Tags throughout the application, including the API
 
 ### SendPortal As A Package
 SendPortal can now be included in an existing application as a package. See [Package Installation](/docs/v2/getting-started/package-installation) for more details.
+
+## Sticking With v1
+If you are not yet ready to upgrade to v2, you will need to ensure you are using a v1 tag. You may already be doing this; however, previous versions of SendPortal were installed by tracking the "master" branch, which always includes the very latest changes.
+
+To check whether you are using a tagged version, navigate to your SendPortal installation and run the following command:
+
+```
+git status
+```
+
+If you see `HEAD detached at v1.0.3`, then you are using a tagged version and don't need to do anything else.
+
+If you see `On branch master`, then you will need to switch to a tagged version in order to avoid any risk of getting unwanted changes.
+
+To do this, run the following command:
+
+```
+git checkout v1.0.3
+```
+
+If you run the `git status` command again you should now see the correct message. You will now be able to continue running v1 of SendPortal without getting unwanted changes. If you want to then go on to perform an upgrade to v2 at a later date, come back to this document and follow the upgrade instructions.
+
+> If you haven't updated your SendPortal installation for some time, v1.0.3 may include changes you haven't previously applied. You should consider running `composer update` followed by `php artisan migrate` to apply any fixes and features included in v1 you may not already have.

--- a/v2/upgrade-guide.md
+++ b/v2/upgrade-guide.md
@@ -2,7 +2,7 @@
 
 > Please see the "Notable Changes" section at the bottom of this document for a list of changes that could impact your use of SendPortal after the upgrade.
 
-> If you do not wish to upgrade to v2, please see the "Sticking With v1" section at the bottom of this document.
+> If you do not wish to upgrade to v2, please see the "Remaining On v1" section at the bottom of this document.
 
 ## Requirements
 
@@ -81,7 +81,7 @@ Segments have been renamed to Tags throughout the application, including the API
 ### SendPortal As A Package
 SendPortal can now be included in an existing application as a package. See [Package Installation](/docs/v2/getting-started/package-installation) for more details.
 
-## Sticking With v1
+## Remaining On v1
 If you are not yet ready to upgrade to v2, you will need to ensure you are using a v1 tag. You may already be doing this; however, previous versions of SendPortal were installed by tracking the "master" branch, which always includes the very latest changes.
 
 To check whether you are using a tagged version, navigate to your SendPortal installation and run the following command:
@@ -90,7 +90,7 @@ To check whether you are using a tagged version, navigate to your SendPortal ins
 git status
 ```
 
-If you see `HEAD detached at v1.0.3`, then you are using a tagged version and don't need to do anything else.
+If you see `HEAD detached at v1.0.3`, or another number starting `v1`, then you are using a tagged version and don't need to do anything else.
 
 If you see `On branch master`, then you will need to switch to a tagged version in order to avoid any risk of getting unwanted changes.
 


### PR DESCRIPTION
## Task
https://app.clickup.com/t/dk354w

## Description
Instruct usage of tags for installation and upgrade

Both the v1 and v2 instructions now ask the user to checkout a specific
tag when performing an installation, rathern than the master branch.
This will avoid any trouble in the future for new installations of
SendPortal.

The upgrade guide for v2 now instructs users to checkout the v2.0.0 tag.

Additionally, a new section has been added telling users who want to
stick with v1 to ensure they are explicitly using a v1 tag, as would be
expected for a new installation. This will help to avoid any trouble for
users who want to stick with v1, as master will stop being applicable to
them.