### PR TITLE
fix(api-urls): v2 urls include workspace

### DIFF
--- a/v2/api-campaigns.md
+++ b/v2/api-campaigns.md
@@ -31,7 +31,7 @@ Retrieve a paginated list of all campaigns.
 
 #### Endpoint
 
-`GET /api/v1/workspaces/{workspaceId}/campaigns`
+`GET /api/v1/campaigns`
 
 #### Expected Response Code
 200
@@ -43,7 +43,7 @@ Retrieve a paginated list of all campaigns.
 #### Sample Request
 
 ```
-GET /api/v1/workspaces/1/campaigns HTTP/1.1
+GET /api/v1/campaigns HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -78,8 +78,8 @@ Accept: application/json
         }
     ],
     "links": {
-        "first": "<https://sendportal.local/api/v1/workspaces/1/campaigns?page=1>",
-        "last": "<https://sendportal.local/api/v1/workspaces/1/campaigns?page=1>",
+        "first": "<https://sendportal.local/api/v1/campaigns?page=1>",
+        "last": "<https://sendportal.local/api/v1/campaigns?page=1>",
         "prev": null,
         "next": null
     },
@@ -87,7 +87,7 @@ Accept: application/json
         "current_page": 1,
         "from": 1,
         "last_page": 1,
-        "path": "<https://sendportal.local/api/v1/workspaces/1/campaigns>",
+        "path": "<https://sendportal.local/api/v1/campaigns>",
         "per_page": 25,
         "to": 1,
         "total": 1
@@ -103,7 +103,7 @@ Get details of a single campaign.
 
 #### Endpoint
 
-`GET /api/v1/workspaces/{workspaceId}/campaigns/{campaignId}`
+`GET /api/v1/campaigns/{campaignId}`
 
 #### Expected Response Code
 200
@@ -115,7 +115,7 @@ Get details of a single campaign.
 #### Sample Request
 
 ```
-GET /api/v1/workspaces/1/campaigns/1 HTTP/1.1
+GET /api/v1/campaigns/1 HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -158,7 +158,7 @@ Create a new campaign.
 
 #### Endpoint
 
-`POST /api/v1/workspaces/{workspaceId}/campaigns`
+`POST /api/v1/campaigns`
 
 #### Expected Response Code
 201
@@ -185,7 +185,7 @@ Create a new campaign.
 #### Sample Request
 
 ```
-POST /api/workspaces/1/campaigns HTTP/1.1
+POST /api/campaigns HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -244,7 +244,7 @@ Update a campaign.
 
 #### Endpoint
 
-`PUT /api/v1/workspaces/{workspaceId}/campaigns/{campaignId}`
+`PUT /api/v1/campaigns/{campaignId}`
 
 #### Expected Response Code
 200
@@ -271,7 +271,7 @@ Update a campaign.
 #### Sample Request
 
 ```
-PUT /api/v1/workspaces/1/campaigns/2 HTTP/1.1
+PUT /api/v1/campaigns/2 HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -320,7 +320,7 @@ Send a campaign.
 
 #### Endpoint
 
-`POST /api/v1/workspaces/{workspaceId}/campaigns/{campaignId}/send`
+`POST /api/v1/campaigns/{campaignId}/send`
 
 #### Expected Response Code
 200
@@ -335,7 +335,7 @@ None
 #### Sample Request
 
 ```
-POST /api/v1/workspaces/1/campaigns/2/send HTTP/1.1
+POST /api/v1/campaigns/2/send HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json

--- a/v2/api-subscriber-tags.md
+++ b/v2/api-subscriber-tags.md
@@ -8,7 +8,7 @@ Retrieve a list of tags that have been assigned to the given subscriber.
 
 #### Endpoint
 
-`GET /api/v1/workspaces/{workspaceId}/subscribers/{subscriberId}/tags`
+`GET /api/v1/subscribers/{subscriberId}/tags`
 
 #### Expected Response Code
 200
@@ -24,7 +24,7 @@ Retrieve a list of tags that have been assigned to the given subscriber.
 #### Sample Request
 
 ```
-GET /api/v1/workspaces/1/subscribers/1/tags HTTP/1.1
+GET /api/v1/subscribers/1/tags HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -53,7 +53,7 @@ This endpoint is idempotent, meaning that tags already assigned to the subscribe
 
 #### Endpoint
 
-`POST /api/v1/workspaces/{workspaceId}/subscribers/{subscriberId}/tags`
+`POST /api/v1/subscribers/{subscriberId}/tags`
 
 #### Expected Response Code
 200
@@ -73,7 +73,7 @@ This endpoint is idempotent, meaning that tags already assigned to the subscribe
 #### Sample Request
 
 ```
-POST /api/v1/workspaces/1/subscribers/1/tags HTTP/1.1
+POST /api/v1/subscribers/1/tags HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -113,7 +113,7 @@ If you want to assign additional tags to the subscriber without removing existin
 
 #### Endpoint
 
-`PUT /api/v1/workspaces/{workspaceId}/subscribers/{subscriberId}/tags`
+`PUT /api/v1/subscribers/{subscriberId}/tags`
 
 #### Expected Response Code
 200
@@ -133,7 +133,7 @@ If you want to assign additional tags to the subscriber without removing existin
 #### Sample Request
 
 ```
-PUT /api/v1/workspaces/1/subscribers/1/tags HTTP/1.1
+PUT /api/v1/subscribers/1/tags HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -173,7 +173,7 @@ Removes the given tags from the subscriber.
 
 #### Endpoint
 
-`DELETE /api/v1/workspaces/{workspaceId}/subscribers/{subscriberId}/tags`
+`DELETE /api/v1/subscribers/{subscriberId}/tags`
 
 #### Expected Response Code
 200
@@ -193,7 +193,7 @@ Removes the given tags from the subscriber.
 #### Sample Request
 
 ```
-DELETE /api/v1/workspaces/1/subscribers/1/tags HTTP/1.1
+DELETE /api/v1/subscribers/1/tags HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json

--- a/v2/api-subscribers.md
+++ b/v2/api-subscribers.md
@@ -8,7 +8,7 @@ Retrieve a paginated list of all subscribers.
 
 #### Endpoint
 
-`GET /api/v1/workspaces/{workspaceId}/subscribers`
+`GET /api/v1/subscribers`
 
 #### Expected Response Code
 200
@@ -27,7 +27,7 @@ Retrieve a paginated list of all subscribers.
 #### Sample Request
 
 ```
-GET /api/v1/workspaces/1/subscribers HTTP/1.1
+GET /api/v1/subscribers HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -58,8 +58,8 @@ Accept: application/json
         }
     ],
     "links": {
-        "first": "<https://sendportal.local/api/v1/workspaces/1/subscribers?page=1>",
-        "last": "<https://sendportal.local/api/v1/workspaces/1/subscribers?page=1>",
+        "first": "<https://sendportal.local/api/v1/subscribers?page=1>",
+        "last": "<https://sendportal.local/api/v1/subscribers?page=1>",
         "prev": null,
         "next": null
     },
@@ -67,7 +67,7 @@ Accept: application/json
         "current_page": 1,
         "from": 1,
         "last_page": 1,
-        "path": "<https://sendportal.local/api/v1/workspaces/1/subscribers>",
+        "path": "<https://sendportal.local/api/v1/subscribers>",
         "per_page": 25,
         "to": 2,
         "total": 2
@@ -83,7 +83,7 @@ Retrieve the details of a single subscriber, including its tags.
 
 #### Endpoint
 
-`GET /api/v1/workspaces/{workspaceId}/subscribers/{subscriberId}`
+`GET /api/v1/subscribers/{subscriberId}`
 
 #### Expected Response Code
 200
@@ -107,7 +107,7 @@ Retrieve the details of a single subscriber, including its tags.
 #### Sample Request
 
 ```
-GET /api/v1/workspaces/1/subscribers/1 HTTP/1.1
+GET /api/v1/subscribers/1 HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -151,7 +151,7 @@ The rules for creating new subscribers or updating existing subscribers are as f
 
 #### Endpoint
 
-`POST /api/v1/workspaces/{workspaceId}/subscribers`
+`POST /api/v1/subscribers`
 
 #### Expected Response Code
 201
@@ -183,7 +183,7 @@ The rules for creating new subscribers or updating existing subscribers are as f
 #### Sample Request
 
 ```
-POST /api/v1/workspaces/1/subscribers HTTP/1.1
+POST /api/v1/subscribers HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -225,7 +225,7 @@ Content-Type: application/json
 
 #### Endpoint
 
-`PUT /api/v1/workspaces/{workspaceId}/subscribers/{subscriberId}`
+`PUT /api/v1/subscribers/{subscriberId}`
 
 #### Expected Response Code
 200
@@ -254,7 +254,7 @@ Update the details of the given subscriber.
 #### Sample Request
 
 ```
-PUT /api/v1/workspaces/1/subscribers/2 HTTP/1.1
+PUT /api/v1/subscribers/2 HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -292,7 +292,7 @@ Delete the given subscriber.
 
 #### Endpoint
 
-`DELETE /api/v1/workspaces/{workspaceId}/subscribers/{subscriberId}`
+`DELETE /api/v1/subscribers/{subscriberId}`
 
 #### Expected Response Code
 204
@@ -300,7 +300,7 @@ Delete the given subscriber.
 #### Sample Request
 
 ```
-DELETE /api/v1/workspaces/1/subscribers/2 HTTP/1.1
+DELETE /api/v1/subscribers/2 HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json

--- a/v2/api-tag-subscribers.md
+++ b/v2/api-tag-subscribers.md
@@ -8,7 +8,7 @@ Retrieve a list of subscribers who have been assigned the given tag.
 
 #### Endpoint
 
-`GET /api/v1/workspaces/{workspaceId}/tags/{tagId}/subscribers`
+`GET /api/v1/tags/{tagId}/subscribers`
 
 #### Expected Response Code
 200
@@ -26,7 +26,7 @@ Retrieve a list of subscribers who have been assigned the given tag.
 #### Sample Request
 
 ```
-GET /api/v1/workspaces/1/tags/1/subscribers HTTP/1.1
+GET /api/v1/tags/1/subscribers HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -57,7 +57,7 @@ This endpoint is idempotent, meaning that subscribers who have already been assi
 
 #### Endpoint
 
-`POST /api/v1/workspaces/{workspaceId}/tags/{tagId}/subscribers`
+`POST /api/v1/tags/{tagId}/subscribers`
 
 #### Expected Response Code
 200
@@ -79,7 +79,7 @@ This endpoint is idempotent, meaning that subscribers who have already been assi
 #### Sample Request
 
 ```
-POST /api/v1/workspaces/1/tags/1/subscribers HTTP/1.1
+POST /api/v1/tags/1/subscribers HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -123,7 +123,7 @@ If you want to assign a tag to additional subscribers without removing existing 
 
 #### Endpoint
 
-`PUT /api/v1/workspaces/{workspaceId}/tags/{tagId}/subscribers`
+`PUT /api/v1/tags/{tagId}/subscribers`
 
 #### Expected Response Code
 200
@@ -145,7 +145,7 @@ If you want to assign a tag to additional subscribers without removing existing 
 #### Sample Request
 
 ```
-PUT /api/v1/workspaces/1/tags/1/subscribers HTTP/1.1
+PUT /api/v1/tags/1/subscribers HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -187,7 +187,7 @@ Removes the given tag from the subscribers provided in the request.
 
 #### Endpoint
 
-`DELETE /api/v1/workspaces/{workspaceId}/tags/{tagId}/subscribers`
+`DELETE /api/v1/tags/{tagId}/subscribers`
 
 #### Expected Response Code
 200
@@ -209,7 +209,7 @@ Removes the given tag from the subscribers provided in the request.
 #### Sample Request
 
 ```
-DELETE /api/v1/workspaces/1/tags/1/subscribers HTTP/1.1
+DELETE /api/v1/tags/1/subscribers HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json

--- a/v2/api-tags.md
+++ b/v2/api-tags.md
@@ -8,7 +8,7 @@ Retrieve a paginated list of tags.
 
 #### Endpoint
 
-`GET /api/v1/workspaces/{workspaceId}/tags`
+`GET /api/v1/tags`
 
 #### Expected Response Code
 200
@@ -24,7 +24,7 @@ Retrieve a paginated list of tags.
 #### Sample Request
 
 ```
-GET /api/v1/workspaces/1/tags HTTP/1.1
+GET /api/v1/tags HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -43,8 +43,8 @@ Accept: application/json
         }
     ],
     "links": {
-        "first": "<https://sendportal.local/api/v1/workspaces/1/tags?page=1>",
-        "last": "<https://sendportal.local/api/v1/workspaces/1/tags?page=1>",
+        "first": "<https://sendportal.local/api/v1/tags?page=1>",
+        "last": "<https://sendportal.local/api/v1/tags?page=1>",
         "prev": null,
         "next": null
     },
@@ -52,7 +52,7 @@ Accept: application/json
         "current_page": 1,
         "from": 1,
         "last_page": 1,
-        "path": "<https://sendportal.local/api/v1/workspaces/1/tags>",
+        "path": "<https://sendportal.local/api/v1/tags>",
         "per_page": 25,
         "to": 1,
         "total": 1
@@ -68,7 +68,7 @@ Get details of a single tag.
 
 #### Endpoint
 
-`GET /api/v1/workspaces/{workspaceId}/tags/{tagId}`
+`GET /api/v1/tags/{tagId}`
 
 #### Expected Response Code
 200
@@ -84,7 +84,7 @@ Get details of a single tag.
 #### Sample Request
 
 ```
-GET /api/v1/workspaces/1/tags/1 HTTP/1.1
+GET /api/v1/tags/1 HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -111,7 +111,7 @@ Create a new tag, optionally including subscribers that should have it assigned 
 
 #### Endpoint
 
-`POST /api/v1/workspaces/{workspaceId}/tags`
+`POST /api/v1/tags`
 
 #### Expected Response Code
 201
@@ -139,7 +139,7 @@ Create a new tag, optionally including subscribers that should have it assigned 
 #### Sample Request
 
 ```
-POST /api/workspaces/1/tags HTTP/1.1
+POST /api/tags HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -182,7 +182,7 @@ Update the details of the given tag. If you wish to adjust the subscribers assoc
 
 #### Endpoint
 
-`PUT /api/v1/workspaces/{workspaceId}/tags/{tagId}`
+`PUT /api/v1/tags/{tagId}`
 
 #### Expected Response Code
 200
@@ -202,7 +202,7 @@ Update the details of the given tag. If you wish to adjust the subscribers assoc
 #### Sample Request
 
 ```
-PUT /api/v1/workspaces/1/tags/2 HTTP/1.1
+PUT /api/v1/tags/2 HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -232,7 +232,7 @@ Delete the given tag.
 
 #### Endpoint
 
-`DELETE /api/v1/workspaces/{workspaceId}/tags/{tagId}`
+`DELETE /api/v1/tags/{tagId}`
 
 #### Expected Response Code
 204
@@ -240,7 +240,7 @@ Delete the given tag.
 #### Sample Request
 
 ```
-DELETE /api/v1/workspaces/1/tags/2 HTTP/1.1
+DELETE /api/v1/tags/2 HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json

--- a/v2/api-templates.md
+++ b/v2/api-templates.md
@@ -8,7 +8,7 @@ Retrieve a paginated list of all templates.
 
 #### Endpoint
 
-`GET /api/v1/workspaces/{workspaceId}/templates`
+`GET /api/v1/templates`
 
 #### Expected Response Code
 200
@@ -25,7 +25,7 @@ Retrieve a paginated list of all templates.
 #### Sample Request
 
 ```
-GET /api/v1/workspaces/1/templates HTTP/1.1
+GET /api/v1/templates HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -45,8 +45,8 @@ Accept: application/json
         }
     ],
     "links": {
-        "first": "http://sendportal.test/api/v1/workspaces/1/templates?page=1",
-        "last": "http://sendportal.test/api/v1/workspaces/1/templates?page=1",
+        "first": "http://sendportal.test/api/v1/templates?page=1",
+        "last": "http://sendportal.test/api/v1/templates?page=1",
         "prev": null,
         "next": null
     },
@@ -54,7 +54,7 @@ Accept: application/json
         "current_page": 1,
         "from": 1,
         "last_page": 1,
-        "path": "http://sendportal.test/api/v1/workspaces/1/templates",
+        "path": "http://sendportal.test/api/v1/templates",
         "per_page": 25,
         "to": 1,
         "total": 1
@@ -70,7 +70,7 @@ Retrieve the details of a single template.
 
 #### Endpoint
 
-`GET /api/v1/workspaces/{workspaceId}/templates/{templateId}`
+`GET /api/v1/templates/{templateId}`
 
 #### Expected Response Code
 200
@@ -87,7 +87,7 @@ Retrieve the details of a single template.
 #### Sample Request
 
 ```
-GET /api/v1/workspaces/1/templates/1 HTTP/1.1
+GET /api/v1/templates/1 HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -115,7 +115,7 @@ Create a new template.
 
 #### Endpoint
 
-`POST /api/v1/workspaces/{workspaceId}/templates`
+`POST /api/v1/templates`
 
 #### Expected Response Code
 201
@@ -137,7 +137,7 @@ Create a new template.
 #### Sample Request
 
 ```
-POST /api/v1/workspaces/1/templates HTTP/1.1
+POST /api/v1/templates HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -167,7 +167,7 @@ Content-Type: application/json
 
 #### Endpoint
 
-`PUT /api/v1/workspaces/{workspaceId}/templates/{templateId}`
+`PUT /api/v1/templates/{templateId}`
 
 #### Expected Response Code
 200
@@ -192,7 +192,7 @@ Update the details of the given template.
 #### Sample Request
 
 ```
-PUT /api/v1/workspaces/1/templates/3 HTTP/1.1
+PUT /api/v1/templates/3 HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json
@@ -226,7 +226,7 @@ Delete the given template.
 
 #### Endpoint
 
-`DELETE /api/v1/workspaces/{workspaceId}/templates/{templateId}`
+`DELETE /api/v1/templates/{templateId}`
 
 #### Expected Response Code
 204
@@ -234,7 +234,7 @@ Delete the given template.
 #### Sample Request
 
 ```
-DELETE /api/v1/workspaces/1/templates/3 HTTP/1.1
+DELETE /api/v1/templates/3 HTTP/1.1
 Host: sendportal.local
 Authorization: Bearer 9w2fN7d4F3Banyv7gihYOWJEH6MvtYyZ
 Accept: application/json


### PR DESCRIPTION
With Version 2 of SendPortal, API Keys are specific to a workspace and because of this, they are no longer needed in the URLs.

This fix adjusts all of them so they no longer reference workspace